### PR TITLE
Dev/joystick mapping and lockout

### DIFF
--- a/spim_core/devices/tiger_components.py
+++ b/spim_core/devices/tiger_components.py
@@ -313,7 +313,7 @@ class Pose:
 
     def unlock_external_user_input(self):
         self.log.info("Releasing joystick control.")
-        self.tigerbox.enable_joystick_input()
+        self.tigerbox.enable_joystick_inputs()
 
 
 class CameraPose(Pose):

--- a/spim_core/spim_base.py
+++ b/spim_core/spim_base.py
@@ -10,6 +10,7 @@ from git import Repo
 from math import ceil
 from pathlib import Path
 
+
 def lock_external_user_input(func):
     """Disable any manual hardware user inputs if possible."""
     @wraps(func)
@@ -17,10 +18,11 @@ def lock_external_user_input(func):
         # Lock user inputs.
         self.lock_external_user_input()
         try:
-            return func(self, *args, kwds)
+            return func(self, *args, **kwds)
         finally:
             # Unlock user inputs.
             self.unlock_external_user_input()
+    return inner
 
 
 class Spim:
@@ -166,10 +168,10 @@ class Spim:
     def run_from_config(self):
         raise NotImplementedError("Child class must implement this function.")
 
-    def lock_external_user_input(self)
+    def lock_external_user_input(self):
         raise NotImplementedError
 
-    def unlock_external_user_input(self)
+    def unlock_external_user_input(self):
         raise NotImplementedError
 
     def start_livestream(self, wavelength: int = None):


### PR DESCRIPTION
Adding joystick lockout at the sample pose level.

This is implemented via context manager. All you need to do is decorate the lowest-level function that you want to lockout with this decorator:
````python
from spim_core.spim_base import lock_external_user_input

@lock_external_user_input
def collect_volumetric_imate(stuff):
    # stuff here...
````
And it will lock the joystick before the function runs and then release it afterwards.

## Testing
Works in simulation!
At the acquisition start, you should see:
![Screenshot from 2023-03-09 14-53-28](https://user-images.githubusercontent.com/706699/224178693-926d57cb-96ce-4249-98d5-b49a4322737a.png)
At the end, you should see:
![Screenshot from 2023-03-09 14-52-47](https://user-images.githubusercontent.com/706699/224178717-2b1ac093-9b2f-4893-a859-fa0b59b08df2.png)
