### PR TITLE
make DataTransfer os-agnostic; write schema logs to their own file.

### DIFF
--- a/spim_core/processes/data_transfer.py
+++ b/spim_core/processes/data_transfer.py
@@ -18,12 +18,17 @@ class DataTransfer(Process):
         if not self.source.exists():
             raise FileNotFoundError(f"{self.source} does not exist.")
         # Transfer the file.
-        # print("SKIPPING FILE TRANSFER TO STORAGE")
         print(f"Transferring {self.source} to storage in {self.dest}.")
-        parameters = '" /q /y /i /j /s /e' if os.path.isdir(self.source) else '*" /y /i /j'
-        print(f"xcopy {self.source} {self.dest}{parameters}")
-        cmd = subprocess.run(f'xcopy "{self.source}" "{self.dest}{parameters}')
-        # Delete the old file so we don't run out of local storage.
-        print(f"Deleting old file at {self.source}.")
+        if os.name == 'nt':  # Explicitly use xcopy on windows.
+            parameters = '" /q /y /i /j /s /e' if os.path.isdir(self.source) else '*" /y /i /j'
+            print(f"xcopy {self.source} {self.dest}{parameters}")
+            cmd = subprocess.run(f'xcopy "{self.source}" "{self.dest}{parameters}')
+            # Delete the old file so we don't run out of local storage.
+            print(f"Deleting old file at {self.source}.")
+        else:
+            if self.source.is_dir():
+                shutil.copytree(self.source, self.dest)
+            else:
+                shutil.copy(self.source, self.dest)
         shutil.rmtree(self.source) if os.path.isdir(self.source) else os.remove(self.source)
         print(f"process finished.")


### PR DESCRIPTION
## Updates

* creates an additional **schema_log.log** file with schemal logs only when you call `run()`
* schema_log the git hashes
* small tweak to `DataTransfer` class to make it work on linux

## Testing:
* works in SPIMulation on Linux.