### PR TITLE
fix local = ext directory edge case

### DIFF
--- a/spim_core/config_base.py
+++ b/spim_core/config_base.py
@@ -146,18 +146,28 @@ class SpimConfig(TomlConfig):
         if z_step_size_um is None:
             self.log.warning("Z Step Size not listed. Defaulting to an "
                              f"isotropic step size of {self.x_voxel_size_um}")
+        # Error if local storage dir is unspecified.
+        try:
+            _ = self.local_storage_dir  # Test access.
+        except KeyError:
+            msg = f"Local storage directory is not defined."
+            self.log.error(msg)
+            error_msgs.append(msg)
         # Warn on no external storage dir.
-        if self.ext_storage_dir == self.local_storage_dir:
+        if self.ext_storage_dir is None:
             self.log.warning("Output storage directory unspecified. Data will "
                              f"be saved to {self.ext_storage_dir.resolve()}.")
         # TODO: Throw error on out-of-bounds stage x, y, or z movement.
-        # TODO: finish refactor.
-        assert 0 < self.tile_overlap_x_percent < 100, \
-            f"Error: Specified x overlap ({self.tile_overlap_x_percent}) " \
-            "is out of bounds."
-        assert 0 < self.tile_overlap_y_percent < 100, \
-            f"Error: Specified x overlap ({self.tile_overlap_x_percent}) " \
-            "is out of bounds."
+        if not (0 < self.tile_overlap_x_percent < 100):
+            msg = f"Error: Specified x overlap ({self.tile_overlap_x_percent}) " \
+                  "is out of bounds."
+            self.log.error(msg)
+            error_msgs.append(msg)
+        if not (0 < self.tile_overlap_y_percent < 100):
+            msg = f"Error: Specified x overlap ({self.tile_overlap_x_percent}) " \
+                  "is out of bounds."
+            self.log.error(msg)
+            error_msgs.append(msg)
 
         # Create a big error message at the end.
         if len(error_msgs):


### PR DESCRIPTION
I made some slight adjustments to clean up the second part.

Like before, it handles the case where:
* Local storage directory undefined --> error
* Local storage directory same as external storage directory --> define necessary subfolders with overwrite checks
* external storage directory undefined --> assume we use the local storage directory. Do overwrite checks

I delegate the double-copy-prevention check to exa-spim-control. We will need to do this for the dispim-control repos, but it's now a one-liner [here](https://github.com/AllenNeuralDynamics/exa-spim-control/blob/7e28b0e97589ca1fe471e1096ebac57ae07e6645/exaspim/exaspim.py#L405).

## Testing
Tested these cases in simulation.
* no local storage directory defined. Throws an error
* local storage directory and external storage directory are the same. Creates underying folder structure where objects point to the same relative points consistenly
* no external storage directory defined. Uses local storage directory as external storage directory.
