### PR TITLE
YAML compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ description = "Core features common across Allen Institute spim systems."
 version = "0.1.0"
 authors = [
     {name = "Adam Glaser", email = "adam.glaser@alleninstitute.org"},
-    {name = "Joshua Vasquez", email = "joshua.vasquez@alleninstitute.org"}
+    {name = "Sonya Vasquez", email = "sonya.vasquez@alleninstitute.org"},
+    {name = "Micah Woodard", email = "micah.woodard@alleninstitute.org"}
 ]
 readme = "README.md"
 keywords = ['microcsopy', 'spim']
@@ -26,13 +27,14 @@ dependencies = [
     "numpy >= 1.22.3",
     "matplotlib >= 3.5.2",
     "toml >= 0.10.2",
+    "ruamel.yaml >= 0.17.35",
     "mock >= 4.0.3",
     "coloredlogs >= 15.0.1",
     "pygit2 >= 1.12.0",
 ]
 
 [project.urls]
-repository = "https://github.com/AllenNeuralDynamics/exa-spim-control"
+repository = "https://github.com/AllenNeuralDynamics/spim-core"
 
 [build-system]
 requires = ["flit-core>=3.7.1,<4"]

--- a/spim_core/config_base.py
+++ b/spim_core/config_base.py
@@ -104,7 +104,7 @@ class Config:
             If file, we use the specified filename.
             If no path specified, we overwrite unless flagged not to do so.
             File extension (yaml or toml) dictates what type of file is
-            written.
+            saved.
         :param overwrite: bool to indicate if we overwrite an existing file.
             Defaults to True so that we can save() over a previous file.
         """
@@ -116,7 +116,7 @@ class Config:
         file_type = write_path.name.split(".")[-1].lower()
         cfg_handler = self.handlers.get(file_type, None)
         if cfg_handler is None:
-            raise RuntimeError("Config file extension not recognized."
+            raise ValueError("Config file extension not recognized."
                                "File must have a *.yaml or *.toml suffix.")
         with write_path.open("w") as f:
             cfg_handler.dump(self.cfg, f)

--- a/spim_core/config_base.py
+++ b/spim_core/config_base.py
@@ -1,28 +1,35 @@
 """TOML wrapper that enables edits, reloads, and manages derived params."""
 
 import toml
+from ruamel.yaml import YAML
 import logging
 from pathlib import Path
 from typing import Union, List
 from numpy import dtype
 
 
-class TomlConfig:
+class Config:
 
-    def __init__(self, toml_filepath: Union[str, None] = None,
+    def __init__(self, filepath: Union[str, None] = None,
                  config_template: Union[dict, None] = None,
                  create: bool = False):
-        """Load an existing config or create one from the specified template.
+        """Load an existing (TOML or YAML) config
+           or create one from the specified template.
 
-            :param toml_filepath: location of the config if we are
+            :param filepath: location of the config if we are
                 loading one from file. Default location to save to. Optional.
-            :param config_template: dict with the same key structure
-                as the TOML file. Optional. Only required if `create` is True.
+            :param config_template: dict with the same key structure as the
+                config file. Optional. Only required if `create` is True.
             :param create: if True, create a config object from the specified
                 `config_template`.
+            :note: comments and file order are not preserved for toml files but
+                *are* preserved in yaml files. This is a quirk of the libraries
+                used to read/write them.
         """
-        self.cfg = None
-        self.path = Path(toml_filepath) if toml_filepath else None
+        self.cfg = None  # The actual type will vary but it can be treated
+                         # as a dict.
+        self.handlers = {"yaml": YAML(), "toml": toml}
+        self.path = Path(filepath) if filepath else None
         self.template = config_template
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         # User specified existing config.
@@ -64,10 +71,16 @@ class TomlConfig:
         """Load a config from file specified in filepath or __init__."""
         if filepath:
             self.path = filepath
-        assert (self.path.is_file() and self.path.exists()), \
-            f"Error: config does not exist at provided filepath: {self.path}."
-        with open(filepath, 'r') as toml_file:
-            self.cfg = toml.load(toml_file)
+        if not (self.path.is_file() and self.path.exists()):
+            raise AssertionError(f"Config does not exist at provided "
+                                 f"filepath: {self.path}.")
+        file_type = self.path.name.split(".")[-1].lower()
+        cfg_handler = self.handlers.get(file_type, None)
+        if cfg_handler is None:
+            raise RuntimeError("Config file extension not recognized."
+                               "File must have a *.yaml or *.toml suffix.")
+        with open(filepath, 'r') as cfg_file:
+            self.cfg = cfg_handler.load(cfg_file)
         self.doc_name = self.path.name
         if not self.template:
             return
@@ -90,6 +103,8 @@ class TomlConfig:
             if filename never specified).
             If file, we use the specified filename.
             If no path specified, we overwrite unless flagged not to do so.
+            File extension (yaml or toml) dictates what type of file is
+            written.
         :param overwrite: bool to indicate if we overwrite an existing file.
             Defaults to True so that we can save() over a previous file.
         """
@@ -98,11 +113,16 @@ class TomlConfig:
         # if file name is unspecified, use the original.
         if write_path.is_dir():
             write_path = write_path / self.doc_name
+        file_type = write_path.name.split(".")[-1].lower()
+        cfg_handler = self.handlers.get(file_type, None)
+        if cfg_handler is None:
+            raise RuntimeError("Config file extension not recognized."
+                               "File must have a *.yaml or *.toml suffix.")
         with write_path.open("w") as f:
-            f.write(toml.dumps(self.cfg))
+            cfg_handler.dump(self.cfg, f)
 
 
-class SpimConfig(TomlConfig):
+class SpimConfig(Config):
 
     def __init__(self, toml_filepath: Union[str, None] = None,
                  config_template: Union[dict, None] = None,

--- a/tests/config_loading.py
+++ b/tests/config_loading.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import filecmp
+import pytest
+from pathlib import Path
+from spim_core.config_base import Config, SpimConfig
+
+
+def test_load_from_yaml():
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_path = this_dir / Path("test_configs/config.yaml")
+    Config(str(config_path))
+
+def test_load_from_toml():
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_path = this_dir / Path("test_configs/config.toml")
+    Config(str(config_path))
+
+def test_save_valid_filetypes():
+    """Ensure we can
+        (1) load a yaml and save a yaml and
+        (1) load a toml and save a toml"""
+    for ext in ["yaml", "toml"]:
+        this_dir = Path(__file__).parent.resolve() # directory of this test file.
+        config_dir = this_dir / Path("test_configs")
+        config_path = this_dir / Path(f"test_configs/config.{ext}")
+        new_config_path = this_dir / Path(f"test_configs/config_output.{ext}")
+        try:
+            cfg = Config(str(config_path))
+            cfg.save(str(new_config_path))
+        finally:
+            new_config_path.unlink() # delete the file we made
+
+def test_load_toml_saveas_yaml():
+    """Load a toml. Save it as a yaml."""
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_dir = this_dir / Path("test_configs")
+    config_path = this_dir / Path("test_configs/config.toml")
+    new_config_path = this_dir / Path("test_configs/config_output.yaml")
+    try:
+        cfg = Config(str(config_path))
+        cfg.save(str(new_config_path))
+    finally:
+        new_config_path.unlink() # delete the file we made
+
+def test_save_wrong_filetype():
+    """Try to save a file with the wrong file extension."""
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_path = this_dir / Path("test_configs/config.yaml")
+    cfg = Config(str(config_path))
+    new_config_path = this_dir / Path("test_configs/config_output.toast")
+    with pytest.raises(ValueError):
+        cfg.save(str(new_config_path))
+
+def test_preserve_yaml_order_and_comments():
+    """Load a valid yaml file with comments in it. Save it to a new file.
+       Diff both files to make sure comments were preserved.
+       Delete the file we made."""
+    # Note: this yaml file has comments in it.
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_dir = this_dir / Path("test_configs")
+    config_path = this_dir / Path("test_configs/config.yaml")
+    new_config_path = this_dir / Path("test_configs/config_output.yaml")
+    files_match = False
+    try:
+        cfg = Config(str(config_path))
+        cfg.save(str(new_config_path))
+        files_match = filecmp.cmp(str(config_path), str(new_config_path))
+    finally:
+        new_config_path.unlink() # delete the file we made
+    assert files_match
+
+
+def test_spim_config_from_yaml():
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_path = this_dir / Path("test_configs/config.yaml")
+    SpimConfig(str(config_path))
+
+def test_spim_config_member_access_from_yaml():
+    """Access various members from an existing config with valid data."""
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_path = this_dir / Path("test_configs/config.yaml")
+    cfg = SpimConfig(str(config_path))
+    # Test accessing various values.
+    assert cfg.column_count_px == 14192
+    assert cfg.x_voxel_size_um == 0.748
+    assert cfg.image_dtype == "uint16"
+
+def test_spim_config_member_writing_from_yaml():
+    """Change members from an existing config with valid data."""
+    this_dir = Path(__file__).parent.resolve() # directory of this test file.
+    config_path = this_dir / Path("test_configs/config.yaml")
+    cfg = SpimConfig(str(config_path))
+    # Test accessing various values.
+    cfg.image_dtype = "uint32"
+    assert cfg.image_dtype == "uint32"
+    # don't save this config.

--- a/tests/test_configs/config.toml
+++ b/tests/test_configs/config.toml
@@ -1,0 +1,188 @@
+[imaging_specs]
+local_storage_directory = "."#"D:\\"
+external_storage_directory = "."#"Y:\\"
+subject_id = "sim_test"
+tile_prefix = "tile"
+tile_overlap_x_percent = 15
+tile_overlap_y_percent = 10
+z_step_size_um = 1
+volume_x_um = 10615.616
+volume_y_um = 7958.7
+volume_z_um = 100
+laser_wavelengths = [ 561,]
+# start_tile_index = 0
+# end_tile_index = 0
+
+[experiment_specs]
+experimenters_name = "Sim Robot"
+immersion_medium = "0.05X SSC"
+immersion_medium_refractive_index = 1.33
+x_anatomical_direction = "Posterior_to_anterior"
+y_anatomical_direction = "Inferior_to_superior"
+z_anatomical_direction = "Right_to_left"
+
+[design_specs]
+slit_width_pixels = 489.0 # 10 # sim size must be reduced for PCs with less ram.
+
+[waveform_specs]
+ttl_pulse_time_s = 0.01
+frame_rest_time_s = 0.05
+
+[compressor_specs]
+image_stack_chunk_size = 64
+compressor_thread_count = 32
+compression_style = "lz4"
+
+[file_transfer_specs]
+protocol = "xcopy"
+protocol_flags = "/j/i/y"
+
+[camera_specs]
+egrabber_frame_buffer = 8
+unpacking_mode = "Msb"
+digital_gain_adu = 1
+line_interval_us = 20.44
+
+[tile_specs]
+x_field_of_view_um = 10615.616
+y_field_of_view_um = 7958.72
+row_count_pixels = 10640 # 320 # sim size must be reduced for PCs with less ram.
+column_count_pixels = 14192 # 240
+data_type = "uint16"
+
+[sample_stage_specs]
+backlash_reset_distance_um = 4
+
+[daq_driver_kwds]
+dev_name = "Dev2"
+samples_per_sec = 10000.0
+
+[tiger_controller_driver_kwds]
+com_port = "COM3"
+
+[estimates]
+
+[daq_driver_kwds.ao_channels]
+etl = 0
+camera = 1
+stage = 2
+488 = 3
+638 = 4
+561 = 13
+405 = 6
+galvo_a = 17
+galvo_b = 19
+
+[channel_specs.488]
+driver = "Oxxius"
+color = "blue"
+hex_color = "#00ff92"
+ao_channel = 3
+ao_voltage = 10.0
+
+[channel_specs.561]
+driver = "Oxxius"
+color = "yellowgreen"
+hex_color = "#c6ff00"
+ao_channel = 5
+ao_voltage = 10.0
+
+[channel_specs.405]
+driver = "Oxxius"
+color = "purple"
+hex_color = "#000000"
+ao_channel = 6
+ao_voltage = 10.0
+
+[channel_specs.638]
+driver = "Oxxius"
+color = "red"
+hex_color = "#000000"
+ao_channel = 4
+ao_voltage = 10.0
+
+[joystick_kwds.axis_map]
+x = 2
+y = 3
+z = 22
+
+[sample_pose_kwds.axis_map]
+x = "y"
+y = "z"
+z = "x"
+
+[channel_specs.488.camera]
+delay_time_s = 0
+
+[channel_specs.488.etl]
+amplitude = 0.105
+offset = 2.494
+nonlinear = 0.0
+interp_time_s = 0.5
+buffer_time_s = 0.05
+
+[channel_specs.488.galvo_a]
+setpoint = -0.5
+
+[channel_specs.488.galvo_b]
+setpoint = -0.5
+
+[channel_specs.488.kwds]
+port = "COMxx"
+
+[channel_specs.561.camera]
+delay_time_s = 0
+
+[channel_specs.561.etl]
+amplitude = 0.1025
+offset = 2.528
+nonlinear = 0.0
+interp_time_s = 0.5
+buffer_time_s = 0.05
+
+[channel_specs.561.galvo_a]
+setpoint = 0
+
+[channel_specs.561.galvo_b]
+setpoint = 0
+
+[channel_specs.561.kwds]
+port = "COMxx"
+
+[channel_specs.405.camera]
+delay_time_s = 0
+
+[channel_specs.405.etl]
+amplitude = 0.105
+offset = 2.494
+nonlinear = 0.0
+interp_time_s = 0.5
+buffer_time_s = 0.05
+
+[channel_specs.405.galvo_a]
+setpoint = -0.5
+
+[channel_specs.405.galvo_b]
+setpoint = -0.5
+
+[channel_specs.405.kwds]
+port = "COMxx"
+
+[channel_specs.638.camera]
+delay_time_s = 0
+
+[channel_specs.638.etl]
+amplitude = 0.105
+offset = 2.494
+nonlinear = 0.0
+interp_time_s = 0.5
+buffer_time_s = 0.05
+
+[channel_specs.638.galvo_a]
+setpoint = -0.5
+
+[channel_specs.638.galvo_b]
+setpoint = -0.5
+
+[channel_specs.638.kwds]
+port = "COMxx"

--- a/tests/test_configs/config.yaml
+++ b/tests/test_configs/config.yaml
@@ -1,0 +1,153 @@
+imaging_specs:
+  local_storage_directory: .
+  external_storage_directory: .
+  subject_id: sim_test
+  tile_prefix: tile
+  tile_overlap_x_percent: 15
+  tile_overlap_y_percent: 10
+  z_step_size_um: 1
+  volume_x_um: 10615.616
+  volume_y_um: 7958.7
+  volume_z_um: 100
+  laser_wavelengths:
+  - 561  # test comment!
+         # test multi-line comment!
+experiment_specs:
+  experimenters_name: Sim Robot
+  immersion_medium: 0.05X SSC
+  immersion_medium_refractive_index: 1.33
+  x_anatomical_direction: Posterior_to_anterior
+  y_anatomical_direction: Inferior_to_superior
+  z_anatomical_direction: Right_to_left
+design_specs:
+  slit_width_pixels: 489.0
+waveform_specs:
+  ttl_pulse_time_s: 0.01
+  frame_rest_time_s: 0.05
+compressor_specs:
+  image_stack_chunk_size: 64
+  compressor_thread_count: 32
+  compression_style: lz4
+file_transfer_specs:
+  protocol: xcopy
+  protocol_flags: /j/i/y
+camera_specs:
+  egrabber_frame_buffer: 8
+  unpacking_mode: Msb
+  digital_gain_adu: 1
+  line_interval_us: 20.44
+tile_specs:
+  x_field_of_view_um: 10615.616
+  y_field_of_view_um: 7958.72
+  row_count_pixels: 10640
+  column_count_pixels: 14192
+  data_type: uint16
+sample_stage_specs:
+  backlash_reset_distance_um: 4
+daq_driver_kwds:
+  dev_name: Dev2
+  samples_per_sec: 10000.0
+  ao_channels:
+    etl: 0
+    camera: 1
+    stage: 2
+    '488': 3
+    '638': 4
+    '561': 13
+    '405': 6
+    galvo_a: 17
+    galvo_b: 19
+tiger_controller_driver_kwds:
+  com_port: COM3
+estimates: {}
+channel_specs:
+  '488':
+    driver: Oxxius
+    color: blue
+    hex_color: '#00ff92'
+    ao_channel: 3
+    ao_voltage: 10.0
+    camera:
+      delay_time_s: 0
+    etl:
+      amplitude: 0.105
+      offset: 2.494
+      nonlinear: 0.0
+      interp_time_s: 0.5
+      buffer_time_s: 0.05
+    galvo_a:
+      setpoint: -0.5
+    galvo_b:
+      setpoint: -0.5
+    kwds:
+      port: COMxx
+  '561':
+    driver: Oxxius
+    color: yellowgreen
+    hex_color: '#c6ff00'
+    ao_channel: 5
+    ao_voltage: 10.0
+    camera:
+      delay_time_s: 0
+    etl:
+      amplitude: 0.1025
+      offset: 2.528
+      nonlinear: 0.0
+      interp_time_s: 0.5
+      buffer_time_s: 0.05
+    galvo_a:
+      setpoint: 0
+    galvo_b:
+      setpoint: 0
+    kwds:
+      port: COMxx
+  '405':
+    driver: Oxxius
+    color: purple
+    hex_color: '#000000'
+    ao_channel: 6
+    ao_voltage: 10.0
+    camera:
+      delay_time_s: 0
+    etl:
+      amplitude: 0.105
+      offset: 2.494
+      nonlinear: 0.0
+      interp_time_s: 0.5
+      buffer_time_s: 0.05
+    galvo_a:
+      setpoint: -0.5
+    galvo_b:
+      setpoint: -0.5
+    kwds:
+      port: COMxx
+  '638':
+    driver: Oxxius
+    color: red
+    hex_color: '#000000'
+    ao_channel: 4
+    ao_voltage: 10.0
+    camera:
+      delay_time_s: 0
+    etl:
+      amplitude: 0.105
+      offset: 2.494
+      nonlinear: 0.0
+      interp_time_s: 0.5
+      buffer_time_s: 0.05
+    galvo_a:
+      setpoint: -0.5
+    galvo_b:
+      setpoint: -0.5
+    kwds:
+      port: COMxx
+joystick_kwds:
+  axis_map:
+    x: 2
+    y: 3
+    z: 22
+sample_pose_kwds:
+  axis_map:
+    x: y
+    y: z
+    z: x


### PR DESCRIPTION
We can now use configs written as either YAML or TOML files.

I found a yaml reader/writer that:
* preserves order
* preserves comments

Given that we have this working, I suggest we switch over to using YAMLs for our configs. To make that easy, this code can actually load TOMLs and save them as YAMLs if you rune `config.save("config.yaml")` where the file saved has a `".yaml"` file extension--even if it was loaded from a TOML file. Otherwise, you can use this script (pasted at the end) to convert our existing TOML configs to a YAML config.

No changes are needed in the other repos to merge this request as-is.

### Testing
I added a test file that you run with pytest. It tests loading/saving/member-access.

I can also confirm that the exa-spim-control code will simulate when running a yaml-style config.


### TOML to YAML conversion script:
````python
#!/usr/bin/env python3

import toml
from pathlib import Path
from ruamel.yaml import YAML
import argparse


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("toml_path", type=str, default=None,
                        help="input path to a toml file.")
    parser.add_argument("--yaml_path", type=str, default=None,
                        help="output path of the yaml file. " +
                             "Defaults to same folder as the toml file.")
    args = parser.parse_args()

    toml_path = Path(args.toml_path)
    if not toml_path.is_file():
        raise RuntimeError("Error: toml path must point to a toml file.")
    if args.yaml_path is None:
        yaml_path = Path(toml_path.parent /
                         Path(str(toml_path.name).rstrip("toml") + "yaml"))
    else:
        yaml_path = Path(args.yaml_path)
        if not yaml_path.is_file():
            raise RuntimeError("Error: yaml path must end with the yaml file "
                               f"to be created.\r\nPath is: {str(yaml_path)}")

    # Do the conversion.
    with open(str(toml_path), 'r') as toml_file:
        cfg_file = toml.load(toml_file)
        with open(str(yaml_path), 'w') as yaml_file:
            yaml = YAML()
            yaml.dump(cfg_file, yaml_file)


if __name__ == "__main__":
    main()
````